### PR TITLE
Adding Gatsby Plugin keywords in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "repository": "https://github.com/rongierlach/gatsby-plugin-github-pages",
   "author": "https://github.com/rongierlach",
   "license": "GPL-3.0",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+  ],
   "scripts": {
     "lint": "standard | snazzy",
     "build": "webpack",


### PR DESCRIPTION
Hello 👋

As part of https://github.com/gatsbyjs/gatsby/issues/14013, I would like to add `gatsby` and `gatsby-plugin` keywords to the package.json file of your plugin.

It is documented in https://www.gatsbyjs.org/contributing/submit-to-plugin-library/ if you would like to know more about it.

If you accept to merge this PR, could you also publish a patch version of your plugin on NPM? Let me know if I can assist in any way with this. 🙂

Thank you very much!